### PR TITLE
Add `cleanup_regex` option for PhoneNumberValidator and PostalCodeValidator

### DIFF
--- a/lib/louche/validators/phone_number_validator.rb
+++ b/lib/louche/validators/phone_number_validator.rb
@@ -2,11 +2,12 @@ class PhoneNumberValidator < ActiveModel::EachValidator
   def initialize(options)
     options.reverse_merge!(message: :invalid_phone_number)
     options.reverse_merge!(regex: /\d{10,}/)
+    options.reverse_merge!(cleanup_regex: /[^\d]/)
     super
   end
 
   def validate_each(record, attribute, value)
-    value = PhoneNumberValidator.format_number(value)
+    value = PhoneNumberValidator.format_number(value, options.fetch(:cleanup_regex))
     record.send(:"#{attribute}=", value)
 
     unless value =~ options.fetch(:regex)
@@ -14,7 +15,7 @@ class PhoneNumberValidator < ActiveModel::EachValidator
     end
   end
 
-  def self.format_number(number)
-    number.try(:gsub, /[^\d]/, '')
+  def self.format_number(number, regex)
+    number.try(:gsub, regex, '')
   end
 end

--- a/lib/louche/validators/postal_code_validator.rb
+++ b/lib/louche/validators/postal_code_validator.rb
@@ -2,11 +2,12 @@ class PostalCodeValidator < ActiveModel::EachValidator
   def initialize(options)
     options.reverse_merge!(message: :invalid_postal_code)
     options.reverse_merge!(regex: /^[a-z]\d[a-z]\d[a-z]\d$/i)
+    options.reverse_merge!(cleanup_regex: /[^a-z0-9]/i)
     super
   end
 
   def validate_each(record, attribute, value)
-    value = PostalCodeValidator.format_code(value)
+    value = PostalCodeValidator.format_code(value, options.fetch(:cleanup_regex))
     record.send(:"#{attribute}=", value)
 
     unless value =~ options.fetch(:regex)
@@ -14,7 +15,7 @@ class PostalCodeValidator < ActiveModel::EachValidator
     end
   end
 
-  def self.format_code(postal_code)
-    postal_code.try(:gsub, /[^a-z0-9]/i, '')
+  def self.format_code(postal_code, regex)
+    postal_code.try(:gsub, regex, '')
   end
 end


### PR DESCRIPTION
It didn’t make sense to allow the customization of the `regex` option and not the `cleanup_regex` one.
