### PR TITLE
Fix regexes for PhoneNumberValidator and PostalCodeValidator

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ user.phone_number # '5552525'
 
 | Option           | Description
 |------------------|-----------------------------------------------------
-| `:regex`         | The regex used to validate the number (default: `/\d{10,}/`)
+| `:regex`         | The regex used to validate the number (default: `/\A\d{10,}\z/`)
 | `:cleanup_regex` | The regex used to validate clean the input before validating/saving it (default: `/[^\d]/`)
 | `:message`       | The ActiveRecord message added to the record errors (default: `:invalid_phone_number`)
 
@@ -111,7 +111,7 @@ user.postal_code # => 'L0L'
 
 | Option           | Description
 |------------------|-----------------------------------------------------
-| `:regex`         | The regex used to validate the code (default: `/^[a-z]\d[a-z]\d[a-z]\d$/i`)
+| `:regex`         | The regex used to validate the code (default: `/\A[a-z]\d[a-z]\d[a-z]\d\z/i`)
 | `:cleanup_regex` | The regex used to validate clean the input before validating/saving it (default: `/[^a-z0-9]/i`)
 | `:message`       | The ActiveRecord message added to the record errors (default: `:invalid_postal_code`)
 

--- a/lib/louche/validators/phone_number_validator.rb
+++ b/lib/louche/validators/phone_number_validator.rb
@@ -1,7 +1,7 @@
 class PhoneNumberValidator < ActiveModel::EachValidator
   def initialize(options)
     options.reverse_merge!(message: :invalid_phone_number)
-    options.reverse_merge!(regex: /\d{10,}/)
+    options.reverse_merge!(regex: /\A\d{10,}\z/)
     options.reverse_merge!(cleanup_regex: /[^\d]/)
     super
   end

--- a/lib/louche/validators/postal_code_validator.rb
+++ b/lib/louche/validators/postal_code_validator.rb
@@ -1,7 +1,7 @@
 class PostalCodeValidator < ActiveModel::EachValidator
   def initialize(options)
     options.reverse_merge!(message: :invalid_postal_code)
-    options.reverse_merge!(regex: /^[a-z]\d[a-z]\d[a-z]\d$/i)
+    options.reverse_merge!(regex: /\A[a-z]\d[a-z]\d[a-z]\d\z/i)
     options.reverse_merge!(cleanup_regex: /[^a-z0-9]/i)
     super
   end

--- a/spec/validators/phone_number_validator_spec.rb
+++ b/spec/validators/phone_number_validator_spec.rb
@@ -51,6 +51,12 @@ describe PhoneNumberValidator do
 
         it_behaves_like 'a successful validator'
       end
+
+      context 'containing trailing characters' do
+        let(:value) { '  514 555-2525  ' }
+        let(:expected_stored_value) { '5145552525' }
+        it_behaves_like 'a successful validator'
+      end
     end
   end
 end

--- a/spec/validators/postal_code_validator_spec.rb
+++ b/spec/validators/postal_code_validator_spec.rb
@@ -53,6 +53,13 @@ describe PostalCodeValidator do
 
         it_behaves_like 'a successful validator'
       end
+
+      context 'with trailing characters' do
+        let(:value) { '  G0R2T0  ' }
+        let(:expected_stored_value) { 'G0R2T0' }
+
+        it_behaves_like 'a successful validator'
+      end
     end
   end
 end


### PR DESCRIPTION
Let’s use stricter regexes.
